### PR TITLE
Fixes #4.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,3 +10,4 @@
 - name: updating ghost mail
   lineinfile: dest={{ ghost_conf }} state=present regexp={{ mail_regexp }} line={{ mail }}
   notify: restart ghost
+  when: mail_user is defined and mail_pass is defined


### PR DESCRIPTION
Skip updating the Ghost `mail` var if `mail_user` or `mail_pass` are not defined.
